### PR TITLE
Remove the /media HTTP URL

### DIFF
--- a/deployment/fc-meeting-app-nginx.conf
+++ b/deployment/fc-meeting-app-nginx.conf
@@ -15,11 +15,6 @@ server {
     # max upload size
     client_max_body_size 20M;
 
-    # Django media
-    location /media  {
-        alias /opt/fc-meeting-app/RWE/media;
-    }
-
     location /static {
         alias /opt/fc-meeting-app/RWE/staticfiles;
     }


### PR DESCRIPTION
Handling of file transfer will be done in django.

Signed-off-by: Damian Jarek <damian.jarek93@gmail.com>